### PR TITLE
Fix Linux Clang/GCC build. Add GitHub build workflows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# All files are checked into the repo with LF
+* text=auto
+
+# Windows batch files are always checked out using CRLF locally
+*.bat eol=crlf
+
+# Shell scripts are always checked out using LF locally
+*.sh eol=lf

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,0 +1,57 @@
+# Build on Linux
+name: Build Linux
+
+on: 
+  workflow_dispatch:
+  push:
+    branches: [ main, github-actions ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Debug, Release]
+        c_compiler: [gcc, clang]
+        include:
+          - c_compiler: gcc
+            cpp_compiler: g++
+          - c_compiler: clang
+            cpp_compiler: clang++
+
+    steps:
+
+    - name: Update packages
+      run: sudo apt-get update
+    
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      
+    - name: Checkout submodules
+      run: git submodule update --init --recursive
+
+    - name: Set reusable strings
+      id: strings
+      shell: bash
+      run: |
+        echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+
+    - name: Configure CMake
+      run: >
+        cmake -B ${{ steps.strings.outputs.build-output-dir }}
+        -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
+        -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
+        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -S ${{ github.workspace }}
+
+    - name: Build
+      run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
+
+    # TODO: Run tests
+    # - name: Test
+    #   working-directory: ${{ steps.strings.outputs.build-output-dir }}
+    #   run: ctest --build-config ${{ matrix.build_type }} --output-on-failure --parallel 8

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,49 @@
+# Build on macOS
+name: Build macOS
+
+on: 
+  workflow_dispatch:
+  push:
+    branches: [ main, github-actions ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-13]  # TODO: Add macos-14 (Apple Silicon)
+        build_type: [Debug, Release]
+
+    steps:
+    
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      
+    - name: Checkout submodules
+      run: git submodule update --init --recursive
+
+    - name: Set reusable strings
+      id: strings
+      shell: bash
+      run: |
+        echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+
+    - name: Configure CMake
+      run: >
+        cmake -B ${{ steps.strings.outputs.build-output-dir }}
+        -DCMAKE_CXX_COMPILER=clang++
+        -DCMAKE_C_COMPILER=clang
+        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -S ${{ github.workspace }}
+
+    - name: Build
+      run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
+
+    # TODO: Run tests
+    # - name: Test
+    #   working-directory: ${{ steps.strings.outputs.build-output-dir }}
+    #   run: ctest --build-config ${{ matrix.build_type }} --output-on-failure --parallel 8

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,48 @@
+# Build on Windows
+name: Build Windows
+
+on: 
+  workflow_dispatch:
+  push:
+    branches: [ main, github-actions ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Debug, Release]
+
+    steps:
+    
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      
+    - name: Checkout submodules
+      run: git submodule update --init --recursive
+
+    - name: Set reusable strings
+      id: strings
+      shell: bash
+      run: |
+        echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+
+    - name: Configure CMake
+      run: >
+        cmake -B ${{ steps.strings.outputs.build-output-dir }}
+        -DCMAKE_CXX_COMPILER=cl
+        -DCMAKE_C_COMPILER=cl
+        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -S ${{ github.workspace }}
+
+    - name: Build
+      run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
+
+    # TODO: Run tests
+    # - name: Test
+    #   working-directory: ${{ steps.strings.outputs.build-output-dir }}
+    #   run: ctest --build-config ${{ matrix.build_type }} --output-on-failure --parallel 8

--- a/.github/workflows/cmake-build-all.yml
+++ b/.github/workflows/cmake-build-all.yml
@@ -1,0 +1,44 @@
+# Build all configs for all platforms
+# This workflow triggers individual platform builds
+
+name: Build All Platforms
+
+on: 
+  workflow_dispatch:
+
+jobs:
+  trigger-builds:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Trigger Linux Build
+      uses: actions/github-script@v7
+      with:
+        script: |
+          github.rest.actions.createWorkflowDispatch({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            workflow_id: 'build-linux.yml',
+            ref: context.ref
+          })
+    
+    - name: Trigger Windows Build  
+      uses: actions/github-script@v7
+      with:
+        script: |
+          github.rest.actions.createWorkflowDispatch({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            workflow_id: 'build-windows.yml',
+            ref: context.ref
+          })
+    
+    - name: Trigger macOS Build
+      uses: actions/github-script@v7
+      with:
+        script: |
+          github.rest.actions.createWorkflowDispatch({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            workflow_id: 'build-macos.yml',
+            ref: context.ref
+          })

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,9 @@ jsmooch-emus/ts
 jsmooch-gui/js
 jsmooch-gui/ts
 ares_test_creator/*
-cmake-*
+cmake-build-*/
+cmake-build-debug/
+cmake-build-release/
 .DS_Store
 *.DS_Store*
 *.gb

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,18 +1,18 @@
 [submodule "jsmooch-lib/src/vendor/elf-parser"]
 	path = jsmooch-lib/src/vendor/elf-parser
-	url = git@github.com:raddad772/elf-parser.git
+	url = https://github.com/raddad772/elf-parser.git
 [submodule "jsmooch-gui/vendor/myimgui"]
 	path = jsmooch-gui/vendor/myimgui
-	url = git@github.com:raddad772/imgui.git
+	url = https://github.com/raddad772/imgui.git
 [submodule "jsmooch-gui/vendor/glfw3webgpu"]
 	path = jsmooch-gui/vendor/glfw3webgpu
-	url = git@github.com:eliemichel/glfw3webgpu.git
+	url = https://github.com/eliemichel/glfw3webgpu.git
 [submodule "jsmooch-gui/vendor/miniaudio"]
 	path = jsmooch-gui/vendor/miniaudio
-	url = https://github.com/raddad772/miniaudio
+	url = https://github.com/raddad772/miniaudio.git
 [submodule "jsmooch-gui/vendor/WebGPU-distribution"]
 	path = jsmooch-gui/vendor/WebGPU-distribution
-	url = git@github.com:eliemichel/WebGPU-distribution.git
+	url = https://github.com/eliemichel/WebGPU-distribution.git
 [submodule "jsmooch-gui/vendor/clownresampler"]
 	path = jsmooch-gui/vendor/clownresampler
-	url = https://github.com/Clownacy/clownresampler
+	url = https://github.com/Clownacy/clownresampler.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,8 @@ set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DDEBUG")
 
 add_subdirectory(jsmooch-lib)
 
-# TODO: Fix jsmooch-gui for Windows
-if(NOT WIN32)
+# TODO: Fix jsmooch-gui for Windows and Linux
+if(APPLE)
     add_subdirectory(jsmooch-gui)
 endif()
 

--- a/README.MD
+++ b/README.MD
@@ -65,3 +65,10 @@ Not ported from JSMoo yet. But, there, only ran a few games. Mostly a proof of c
 Mostly plays games fine, but not thoroughly tested
 
 More detailed info on each to come!
+
+## Build status
+
+[![Build Linux](https://github.com/raddad772/jsmooch-emus-win/actions/workflows/build-linux.yml/badge.svg)](https://github.com/raddad772/jsmooch-emus-win/actions/workflows/build-linux.yml)
+[![Build Windows](https://github.com/raddad772/jsmooch-emus-win/actions/workflows/build-windows.yml/badge.svg)](https://github.com/raddad772/jsmooch-emus-win/actions/workflows/build-windows.yml)
+[![Build macOS](https://github.com/raddad772/jsmooch-emus-win/actions/workflows/build-macos.yml/badge.svg)](https://github.com/raddad772/jsmooch-emus-win/actions/workflows/build-macos.yml)
+

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,5 @@
 # TODO
-
-- Get 68000 test running
-- Add GitHub workflow to allow Windows to be built on demand
-- Fix test_bitbuf()
-
-## Future tasks
+- Fix macOS build: Dawn dependency
 - Remove all "#pragma warning(disable, ..." and fix warnings
-- Increase warning level to 4 for MSVC
+- Increase warning level to 4 for MSVC and fix warnings
+- Add -Wall for GCC and Clang and fix warnings

--- a/jsmooch-gui/CMakeLists.txt
+++ b/jsmooch-gui/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)
 
+set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
+
 add_definitions(-DJSM_WEBGPU)
 add_definitions(-DIMGUI_IMPL_WEBGPU_BACKEND_DAWN)
 include_directories(~/dev/libs/include)
@@ -11,7 +13,12 @@ link_directories(~/dev/libs/bin)
 #option(TINT_BUILD_DOCS "Build documentation" OFF)
 #option(TINT_BUILD_TESTS "Build tests" OFF)
 
-add_executable(jsmooch-gui
+add_executable(jsmooch-gui)
+
+# Add application src
+target_sources(
+        jsmooch-gui 
+        PRIVATE 
         src/full_sys.cpp
         src/full_sys.h
         src/application.h
@@ -29,23 +36,54 @@ add_executable(jsmooch-gui
         src/my_texture_ogl3.cpp
         src/my_texture_wgpu.cpp
 )
-set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
+
+# Add a subset of ImGui source files directly to the executable to fit our use case
+target_sources(
+        jsmooch-gui
+        PRIVATE
+
+        # Among the different backends available, we are interested in connecting
+        # the GUI to GLFW andWebGPU:
+        vendor/myimgui/backends/imgui_impl_wgpu.h
+        vendor/myimgui/backends/imgui_impl_wgpu.cpp
+        vendor/myimgui/backends/imgui_impl_glfw.h
+        vendor/myimgui/backends/imgui_impl_glfw.cpp
+
+        # Bonus to add some C++ specific features (the core ImGUi is a C library)
+        vendor/myimgui/misc/cpp/imgui_stdlib.h
+        vendor/myimgui/misc/cpp/imgui_stdlib.cpp
+
+        # The core ImGui files
+        vendor/myimgui/imconfig.h
+        vendor/myimgui/imgui.h
+        vendor/myimgui/imgui.cpp
+        vendor/myimgui/imgui_draw.cpp
+        vendor/myimgui/imgui_internal.h
+        vendor/myimgui/imgui_tables.cpp
+        vendor/myimgui/imgui_widgets.cpp
+        vendor/myimgui/imstb_rectpack.h
+        vendor/myimgui/imstb_textedit.h
+        vendor/myimgui/imstb_truetype.h
+)
 
 #FIND_PACKAGE(SDL2 REQUIRED)
-
 #include_directories( ${SDL2_INCLUDE_DIR} )
-include_directories(${CMAKE_SOURCE_DIR}/jsmooch-lib/src)
 
-add_subdirectory(vendor/myimgui)
+target_include_directories(
+    jsmooch-gui
+    PRIVATE
+    ${CMAKE_SOURCE_DIR}/jsmooch-lib/src
+    vendor/myimgui
+)
+
 #add_subdirectory(vendor/WebGPU-distribution)
 #add_subdirectory(vendor/glfw3webgpu)
 #find_package(Dawn)
 
 # [...]
 
-
-#target_link_libraries(jsmooch-gui jsmooch-lib imgui SDL3 "-framework OpenGL")
-target_link_libraries(jsmooch-gui jsmooch-lib imgui glfw3 imgui webgpu_dawn dawn_glfw "-framework CoreFoundation" "-framework AppKit" "-framework Cocoa" "-framework IOKit" "-framework OpenGL" "-framework Quartz")
+#target_link_libraries(jsmooch-gui jsmooch-lib SDL3 "-framework OpenGL")
+target_link_libraries(jsmooch-gui jsmooch-lib glfw3 webgpu_dawn dawn_glfw "-framework CoreFoundation" "-framework AppKit" "-framework Cocoa" "-framework IOKit" "-framework OpenGL" "-framework Quartz")
 #webgpu glfw3webgpu webgpu_cpp  webgpu_glfw
 #target_link_libraries(jsmooch-gui PRIVATE )
 

--- a/jsmooch-gui/src/keymap_translate.cpp
+++ b/jsmooch-gui/src/keymap_translate.cpp
@@ -2,6 +2,7 @@
 // Created by . on 8/4/24.
 //
 #include <stdio.h>
+#include <stdlib.h> // abort()
 
 #include "keymap_translate.h"
 
@@ -39,8 +40,9 @@ enum ImGuiKey jk_to_imgui_gp(enum JKEYS key_id) {
             return ImGuiKey_GamepadR2;
         case DBCID_co_shoulder_left2:
             return ImGuiKey_GamepadL2;
+        default:
+            NOGOHERE;
     }
-    NOGOHERE;
 }
 
 enum ImGuiKey jk_to_imgui(enum JKEYS key_id) {

--- a/jsmooch-lib/CMakeLists.txt
+++ b/jsmooch-lib/CMakeLists.txt
@@ -508,7 +508,14 @@ add_library(jsmooch-lib ${SOURCE_LIST})
 set_property(TARGET jsmooch-lib PROPERTY COMPILE_WARNING_AS_ERROR ON)
 
 # Compiler-specific options
-if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang") # Linux Clang
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror -Wno-format")
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU") # GCC
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror -Wno-format -Wno-unused-result")
+    target_link_libraries(jsmooch-lib PRIVATE m) # link against maths library (-lm) for sh4_interpreter_opcodes.c sqrt/sqrtf
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_options(
         jsmooch-lib
         PRIVATE
@@ -524,7 +531,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     # Allow use of portable fopen (fopen_s is Windows only)
 	target_compile_definitions(jsmooch-lib PUBLIC _CRT_SECURE_NO_WARNINGS)
 else()
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+	message(FATAL_ERROR, "Unknown compiler")
 endif()
 
 include_directories(src/)

--- a/jsmooch-lib/code_gen/huc6280/huc6280_gen.py
+++ b/jsmooch-lib/code_gen/huc6280/huc6280_gen.py
@@ -1757,7 +1757,7 @@ def main():
     if os.path.isfile(outinsfile):
         os.unlink(outinsfile)
     with open(outinsfile, 'w') as outfile:
-        outfile.write('#include <printf.h>\n')
+        outfile.write('#include <stdio.h>\n')
         outfile.write('#include <assert.h>\n')
         outfile.write('#include "helpers/int.h"\n')
         outfile.write('#include "huc6280_opcodes.h"\n')

--- a/jsmooch-lib/src/component/cpu/huc6280/huc6280.c
+++ b/jsmooch-lib/src/component/cpu/huc6280/huc6280.c
@@ -3,12 +3,7 @@
 //
 #include <assert.h>
 #include <string.h>
-
-#if !defined(_MSC_VER)
-#include <printf.h>
-#else
 #include <stdio.h>
-#endif
 
 #include "helpers/debug.h"
 #include "helpers/debugger/debugger.h"

--- a/jsmooch-lib/src/component/cpu/huc6280/huc6280_disassembler.c
+++ b/jsmooch-lib/src/component/cpu/huc6280/huc6280_disassembler.c
@@ -1,7 +1,7 @@
 //
 // Created by Dave on 2/4/2024.
 //
-#include <printf.h>
+#include <stdio.h>
 #include "huc6280.h"
 #include "huc6280_disassembler.h"
 

--- a/jsmooch-lib/src/component/cpu/huc6280/huc6280_opcodes.c
+++ b/jsmooch-lib/src/component/cpu/huc6280/huc6280_opcodes.c
@@ -1,4 +1,4 @@
-#include <printf.h>
+#include <stdio.h>
 #include <assert.h>
 #include "helpers/int.h"
 #include "huc6280_opcodes.h"

--- a/jsmooch-lib/src/component/cpu/r3000/gte.c
+++ b/jsmooch-lib/src/component/cpu/r3000/gte.c
@@ -5,11 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
-#if defined(_MSC_VER)
 #include <stdio.h>
-#else
-#include <printf.h>
-#endif
 
 #include "helpers/intrinsics.h"
 

--- a/jsmooch-lib/src/component/cpu/r3000/r3000.c
+++ b/jsmooch-lib/src/component/cpu/r3000/r3000.c
@@ -3,11 +3,7 @@
 //
 #include <stdlib.h>
 #include <string.h>
-#if defined(_MSC_VER)
-#include <stdio.h>
-#else
-#include <printf.h>
-#endif
+#include <stdio.h> // printf
 
 #include "r3000_instructions.h"
 #include "r3000.h"

--- a/jsmooch-lib/src/component/cpu/r3000/r3000_instructions.c
+++ b/jsmooch-lib/src/component/cpu/r3000/r3000_instructions.c
@@ -3,13 +3,7 @@
 //
 
 #include <assert.h>
-
-#if !defined(_MSC_VER)
-#include <printf.h>
-#else
 #include <stdio.h>
-#endif
-
 #include <stdlib.h>
 #include "helpers/intrinsics.h"
 #include "r3000.h"

--- a/jsmooch-lib/src/component/cpu/sh4/sh4_interpreter.c
+++ b/jsmooch-lib/src/component/cpu/sh4/sh4_interpreter.c
@@ -93,19 +93,19 @@ void SH4_regs_FPSCR_update(struct SH4_regs_FPSCR* this, u32 old_RM, u32 old_DN)
 
             u32 temp=0x1f80;	//no flush to zero && round to nearest
 
-			if (fpscr.RM==1)  //if round to 0 , set the flag
+			if (this->RM==1)  //if round to 0 , set the flag
 				temp|=(3<<13);
 
-			if (fpscr.DN)     //denormals are considered 0
+			if (this->DN)     //denormals are considered 0
 				temp|=(1<<15);
 			asm("ldmxcsr %0" : : "m"(temp));
     #elif HOST_CPU==CPU_ARM
 		static const unsigned int x = 0x04086060;
 		unsigned int y = 0x02000000;
-		if (fpscr.RM==1)  //if round to 0 , set the flag
+		if (this->RM==1)  //if round to 0 , set the flag
 			y|=3<<22;
 
-		if (fpscr.DN)
+		if (this->DN)
 			y|=1<<24;
 
 

--- a/jsmooch-lib/src/component/gpu/huc6260/huc6260.c
+++ b/jsmooch-lib/src/component/gpu/huc6260/huc6260.c
@@ -3,12 +3,7 @@
 //
 
 #include <string.h>
-
-#if !defined(_MSC_VER)
-#include <printf.h>
-#else
 #include <stdio.h>
-#endif
 
 #include "component/gpu/huc6270/huc6270.h"
 #include "huc6260.h"

--- a/jsmooch-lib/src/component/gpu/huc6270/huc6270.c
+++ b/jsmooch-lib/src/component/gpu/huc6270/huc6270.c
@@ -3,11 +3,7 @@
 //
 
 #include <string.h>
-#if !defined(_MSC_VER)
-#include <printf.h>
-#else
 #include <stdio.h>
-#endif
 
 #include "huc6270.h"
 #include "component/gpu/huc6260/huc6260.h"

--- a/jsmooch-lib/src/helpers/audiobuf.c
+++ b/jsmooch-lib/src/helpers/audiobuf.c
@@ -4,9 +4,6 @@
 
 #include <string.h>
 #include <stdlib.h>
-#if !defined(_MSC_VER)
-#include <printf.h>
-#endif
 
 #include "audiobuf.h"
 

--- a/jsmooch-lib/src/helpers/int.h
+++ b/jsmooch-lib/src/helpers/int.h
@@ -5,17 +5,36 @@
 extern "C" {
 #endif
 
-#define COMPILER_VC 1
+#define CPU_X86   2
+#define CPU_X64   3
+#define CPU_ARM   4
+#define CPU_ARM64 5
+
+#if defined(__arm__) // 32bit arm, and 32bit arm only.
+#define HOST_CPU CPU_ARM
+#elif defined(__aarch64__) // 64bit arm, and 64bit arm only.
+#define HOST_CPU CPU_ARM64
+#elif defined(__x86_64__) || defined(_M_X64)
+#define HOST_CPU CPU_X64
+#elif defined(i386) || defined(__i386__) || defined(__i386) || defined(_M_IX86)
+#define HOST_CPU CPU_X86
+#else
+#error Unsupported CPU architecture
+#endif
+
+#define COMPILER_VC    1
+#define COMPILER_GCC   2
 #define COMPILER_CLANG 3
+
 #if defined(__clang__)
 #define BUILD_COMPILER COMPILER_CLANG
+#elif defined(__GNUC__)
+#define BUILD_COMPILER COMPILER_GCC
 #elif defined(_MSC_VER)
 #define BUILD_COMPILER COMPILER_VC
 #else
 #error Unsupported compiler
 #endif
-#define CPU_ARM64 5
-#define HOST_CPU CPU_ARM64
 
 /* If you are somehow on a big-endian platform, you must change this */
 #define ENDIAN_LITTLE

--- a/jsmooch-lib/src/helpers/irq_multiplexer.c
+++ b/jsmooch-lib/src/helpers/irq_multiplexer.c
@@ -2,10 +2,6 @@
 // Created by . on 2/15/25.
 //
 
-#if !defined(_MSC_VER)
-#include <printf.h>
-#endif
-
 #include "irq_multiplexer.h"
 
 void IRQ_multiplexer_init(struct IRQ_multiplexer *this)

--- a/jsmooch-lib/src/system/dreamcast/maple.c
+++ b/jsmooch-lib/src/system/dreamcast/maple.c
@@ -4,6 +4,7 @@
 
 #include "assert.h"
 #include "stdio.h"
+#include "stdlib.h" // abort()
 #include "dreamcast.h"
 #include "holly.h"
 #include "maple.h"

--- a/jsmooch-lib/src/system/tg16/tg16_bus.c
+++ b/jsmooch-lib/src/system/tg16/tg16_bus.c
@@ -2,11 +2,7 @@
 // Created by . on 6/18/25.
 //
 
-#if defined(_MSC_VER)
 #include <stdio.h>
-#else
-#include <printf.h>
-#endif
 
 #include "tg16_bus.h"
 

--- a/jsmooch-lib/src/system/zxspectrum/ula.c
+++ b/jsmooch-lib/src/system/zxspectrum/ula.c
@@ -271,7 +271,7 @@ static void new_scanline(struct ZXSpectrum* bus)
             this->scanline_func = &scanline_vblank;
             break;
         case 16: // lines 8-63 are upper border. 8-62 on 128k
-            switch(this->variant)
+            //switch(this->variant) // Assume this was a typo!
             this->scanline_func = &scanline_border_top;
             break;
         case 63:

--- a/jsmooch-tests/CMakeLists.txt
+++ b/jsmooch-tests/CMakeLists.txt
@@ -46,7 +46,15 @@ set_property(TARGET jsmooch-tests PROPERTY COMPILE_WARNING_AS_ERROR ON)
 include_directories(${CMAKE_SOURCE_DIR}/jsmooch-lib/src ${CMAKE_SOURCE_DIR}/jsmooch-tests/lib)
 
 # Compiler-specific options
-if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang") # Linux Clang
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror -Wno-format")
+    target_link_libraries(jsmooch-tests PRIVATE m) # link against maths library (-lm) for sh4_interpreter_opcodes.c sqrt/sqrtf
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU") # GCC
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror -Wno-format -Wno-unused-result")
+    target_link_libraries(jsmooch-tests PRIVATE m) # link against maths library (-lm) for sh4_interpreter_opcodes.c sqrt/sqrtf
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_options(
         jsmooch-tests
         PRIVATE
@@ -60,12 +68,12 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     # Allow use of portable fopen (fopen_s is Windows only)
 	target_compile_definitions(jsmooch-tests PUBLIC _CRT_SECURE_NO_WARNINGS)
 else()
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+	message(FATAL_ERROR, "Unknown compiler")
 endif()
 
 link_directories(${CMAKE_SOURCE_DIR}/jsmooch-tests/lib)
 
-target_link_libraries(jsmooch-tests jsmooch-lib)# jansson)
+target_link_libraries(jsmooch-tests PRIVATE jsmooch-lib)# jansson)
 
 install(TARGETS jsmooch-tests RUNTIME DESTINATION bin)
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Allow script to be launched from any directory
+SOURCE=${BASH_SOURCE[0]}
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+#echo "SOURCE is '$SOURCE'"
+#echo "SCRIPT_DIR is '$SCRIPT_DIR"
+pushd $SCRIPT_DIR/.. > /dev/null
+
+# Determine the operating system
+unameOut="$(uname -s)"
+case "${unameOut}" in
+    Linux*)     machine=Linux;;
+    Darwin*)    machine=Mac;;
+    *)          machine="UNKNOWN:${unameOut}"
+esac
+#echo ${machine}
+
+if [ "$machine" == "Mac" ]; then
+    echo "Mac build script not implemented yet"
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+
+    echo "Building GCC Debug"
+    cmake -S . -B build/gcc/debug -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++
+    ninja -C build/gcc/debug
+
+    echo "Building GCC Release"
+    cmake -S . -B build/gcc/release -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++
+    ninja -C build/gcc/release
+
+    echo "Building Clang Debug"
+    cmake -S . -B build/clang/debug -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++
+    ninja -C build/clang/debug
+
+    echo "Building Clang Release"
+    cmake -S . -B build/clang/release -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++
+    ninja -C build/clang/release
+fi
+
+# return to original directory
+popd > /dev/null

--- a/scripts/gensln.bat
+++ b/scripts/gensln.bat
@@ -18,8 +18,10 @@ if %VisualStudioVersion% == 15.0 (
 
 REM Set the current directory to the location of the batch script, using the %0 parameter
 REM This allows the script to be called from anywhere
-cd "%~dp0"
+pushd "%~dp0"
 
-cmake -B build -S . -G %CMAKE_GENERATOR% -A x64 || EXIT /B 1
+cmake -B ..\build -S .. -G %CMAKE_GENERATOR% -A x64 || EXIT /B 1
+
+popd
 
 EXIT /B


### PR DESCRIPTION
This PR allows the lib and tests to build for Linux Clang/GCC build and adds GitHub build workflows for all platforms: macOS (AppleClang), Linux (Clang and GCC) and Windows (MSCV)

Linux and Windows builds are passing (except for bug in parent repo, see below). But these don't build the gui.
The macOS builds are failing because they build gui, which depends on Dawn and is not set up as a dependency.

Full changes:
- Add GitHub Actions Workflows to build macOS (AppleClang), Linux (Clang and GCC) and Windows (MSCV)
- Fix .gitmodules paths so work on all platforms (including GitHub Actions)
- Add ImGui src directly to jsmooch-gui build target to workaround missing CMakelists.txt.
  - Src still comes from the forked submodule
- Add .gitattributes to ensure consistent line endings on all platforms.
- Fix what looked like a copy-paste bug in zxspectrum/ula.c (rouge switch)

It looks like the main repo is currently not working so may need fixing up:

`src/cpu-tests/huc6280_tests.c(528,5): error C2198: 'void HUC6280_setup_tracing(HUC6280 *,jsm_debug_read_trace *,u64 *,i32)': too few arguments for call`